### PR TITLE
[MMSDK-38] Adding optionable share

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ ClipPayment.Builder()
 
 
 
+- **isShareEnabled**: This parameter sets if share buttons are available in transaction success. When set to true, the terminal will you share options in success. If set to false, the terminal will not show share options in success.
+
+```Payment.kt  
+ClipPayment.Builder()
+	.isShareEnabled(isShareEnabled: Boolean)
+```
+
+
+
 - **addListener**: With this parameter, you can register a listener to receive transaction results. This allows you to handle the outcome of the transaction within your application.
 
 ```Payment.kt  

--- a/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/domain/builder/payment/ClipPayment.kt
+++ b/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/domain/builder/payment/ClipPayment.kt
@@ -19,6 +19,7 @@ class ClipPayment internal constructor(
     private val launcher: ClipLauncher,
     private val isAutoReturnEnabled: Boolean,
     private val isRetryEnabled: Boolean,
+    private val isShareEnabled: Boolean,
     private val preferences: PaymentPreferences,
     private val listener: PaymentListener?
 ) {
@@ -32,6 +33,8 @@ class ClipPayment internal constructor(
         private var isAutoReturnEnabled: Boolean = false
 
         private var isRetryEnabled: Boolean = true
+
+        private var isShareEnabled: Boolean = true
 
         private var preferences: PaymentPreferences = PaymentPreferences()
 
@@ -55,6 +58,16 @@ class ClipPayment internal constructor(
          */
         fun isRetryEnabled(isEnabled: Boolean) = apply {
             this.isRetryEnabled = isEnabled
+        }
+
+        /**
+         * Method to settle if share buttons will be shown.
+         *
+         * @param isEnabled If it is true, the terminal will you share options in success.
+         * If set to false, the terminal will not show share options in success.
+         */
+        fun isShareEnabled(isEnabled: Boolean) = apply {
+            this.isShareEnabled = isEnabled
         }
 
         /**
@@ -89,6 +102,7 @@ class ClipPayment internal constructor(
                 launcher = launcher,
                 isAutoReturnEnabled = isAutoReturnEnabled,
                 isRetryEnabled = isRetryEnabled,
+                isShareEnabled = isShareEnabled,
                 preferences = preferences,
                 listener = listener
             )
@@ -143,6 +157,7 @@ class ClipPayment internal constructor(
                     amount = amount,
                     isAutoReturnEnabled = isAutoReturnEnabled,
                     isRetryEnabled = isRetryEnabled,
+                    isShareEnabled = isShareEnabled,
                     preferences = preferences
                 )
             }

--- a/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/ui/intent/ClipIntentProvider.kt
+++ b/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/ui/intent/ClipIntentProvider.kt
@@ -2,7 +2,6 @@ package com.payclip.blaze.pinpad.sdk.ui.intent
 
 import android.content.Intent
 import com.payclip.blaze.pinpad.sdk.domain.models.payment.settings.PaymentPreferences
-import com.payclip.blaze.pinpad.sdk.ui.intent.system.SystemClipIntentProvider
 
 interface ClipIntentProvider {
 
@@ -15,6 +14,8 @@ interface ClipIntentProvider {
      * auto return to your application. Otherwise you will see a defined screen with information.
      * @param isRetryEnabled If it is true, when the payment process throw error, you will
      * have the chance to retry. Otherwise you will only be able to cancel.
+     * @param isShareEnabled If it is true, the terminal will you share options in success.
+     * If set to false, the terminal will not show share options in success.
      * @param preferences An object loaded with all payment configuration.
      *
      * @return [Intent] with extras pointing to PinPad application.
@@ -24,6 +25,7 @@ interface ClipIntentProvider {
         amount: Double,
         isAutoReturnEnabled: Boolean = false,
         isRetryEnabled: Boolean = true,
+        isShareEnabled: Boolean = true,
         preferences: PaymentPreferences
     ): Intent
 
@@ -62,6 +64,15 @@ interface ClipIntentProvider {
      * @return The retry availability state. If retry availability was not settled, null is returned.
      */
     fun isRetryEnabled(intent: Intent): Boolean?
+
+    /**
+     * Get share buttons availability from intent extras.
+     *
+     * @param intent activity intent with extras.
+     *
+     * @return The share buttons availability state. If share availability was not settled, null is returned.
+     */
+    fun isShareEnabled(intent: Intent): Boolean?
 
     /**
      * Get payment preferences from intent extras.

--- a/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/ui/intent/system/SystemClipIntentProvider.kt
+++ b/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/ui/intent/system/SystemClipIntentProvider.kt
@@ -14,6 +14,7 @@ internal class SystemClipIntentProvider : ClipIntentProvider {
         amount: Double,
         isAutoReturnEnabled: Boolean,
         isRetryEnabled: Boolean,
+        isShareEnabled: Boolean,
         preferences: PaymentPreferences
     ): Intent {
         return Intent(Intent.ACTION_MAIN).apply {
@@ -22,6 +23,7 @@ internal class SystemClipIntentProvider : ClipIntentProvider {
             putExtra(PAYMENT_AMOUNT_EXTRA, amount.toString())
             putExtra(PAYMENT_AUTO_RETURN_EXTRA, isAutoReturnEnabled)
             putExtra(PAYMENT_RETRY_EXTRA, isRetryEnabled)
+            putExtra(PAYMENT_SHARE_EXTRA, isShareEnabled)
             putExtra(PAYMENT_PREFERENCES_EXTRA, preferences)
         }
     }
@@ -42,6 +44,10 @@ internal class SystemClipIntentProvider : ClipIntentProvider {
         return intent.extras?.getBoolean(PAYMENT_RETRY_EXTRA)
     }
 
+    override fun isShareEnabled(intent: Intent): Boolean? {
+        return intent.extras?.getBoolean(PAYMENT_SHARE_EXTRA)
+    }
+
     @Suppress("DEPRECATION")
     override fun getPaymentPreferences(intent: Intent): PaymentPreferences {
         val preferences = when {
@@ -60,6 +66,7 @@ internal class SystemClipIntentProvider : ClipIntentProvider {
 
         private const val PAYMENT_REFERENCE_EXTRA = "PAYMENT_REFERENCE"
         private const val PAYMENT_AMOUNT_EXTRA = "PAYMENT_AMOUNT"
+        private const val PAYMENT_SHARE_EXTRA = "PAYMENT_SHARE"
         private const val PAYMENT_RETRY_EXTRA = "PAYMENT_RETRY"
         private const val PAYMENT_AUTO_RETURN_EXTRA = "PAYMENT_AUTO_RETURN"
         private const val PAYMENT_PREFERENCES_EXTRA = "PAYMENT_PREFERENCES"

--- a/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/ui/launcher/ClipLauncher.kt
+++ b/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/ui/launcher/ClipLauncher.kt
@@ -50,6 +50,8 @@ internal interface ClipLauncher {
      * auto return to your application. Otherwise you will see a defined screen with information.
      * @param isRetryEnabled If it is true, when the payment process throw error, you will
      * have the chance to retry. Otherwise you will only be able to cancel.
+     * @param isShareEnabled If it is true, the terminal will you share options in success.
+     * If set to false, the terminal will not show share options in success.
      * @param preferences An object loaded with all payment configuration.
      */
     fun startPayment(
@@ -57,6 +59,7 @@ internal interface ClipLauncher {
         amount: Double,
         isAutoReturnEnabled: Boolean = false,
         isRetryEnabled: Boolean = true,
+        isShareEnabled: Boolean = true,
         preferences: PaymentPreferences
     )
 }

--- a/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/ui/launcher/activity/ActivityClipLauncher.kt
+++ b/pinpad-sdk/src/main/java/com/payclip/blaze/pinpad/sdk/ui/launcher/activity/ActivityClipLauncher.kt
@@ -91,6 +91,7 @@ internal class ActivityClipLauncher constructor(
         amount: Double,
         isAutoReturnEnabled: Boolean,
         isRetryEnabled: Boolean,
+        isShareEnabled: Boolean,
         preferences: PaymentPreferences
     ) {
         val launcher = getLauncher()
@@ -99,6 +100,7 @@ internal class ActivityClipLauncher constructor(
             amount = amount,
             isAutoReturnEnabled = isAutoReturnEnabled,
             isRetryEnabled = isRetryEnabled,
+            isShareEnabled = isShareEnabled,
             preferences = preferences
         )
 

--- a/pinpad-sdk/src/test/java/com/payclip/blaze/pinpad/sdk/domain/usecases/ClipPaymentTest.kt
+++ b/pinpad-sdk/src/test/java/com/payclip/blaze/pinpad/sdk/domain/usecases/ClipPaymentTest.kt
@@ -27,6 +27,7 @@ class ClipPaymentTest {
         ClipPayment.Builder()
             .isAutoReturnEnabled(AUTO_RETURN)
             .isRetryEnabled(RETRY)
+            .isShareEnabled(SHARE)
             .setPaymentPreferences(getPaymentPreferences())
             .addListener(getEmptyListener())
             .build()
@@ -82,6 +83,25 @@ class ClipPaymentTest {
             amount = AMOUNT,
             isAutoReturnEnabled = false,
             isRetryEnabled = false,
+            preferences = preferences
+        )
+    }
+
+    @Test
+    fun `create payment with success response and share options disabled and check if the result is right`() = runTest {
+        val preferences = getPaymentPreferences()
+        val payment = getPaymentInstance(isShareEnabled = false)
+
+        whenever(useCase.invoke(REFERENCE, AMOUNT)).thenReturn(Result.success(Unit))
+
+        payment.start(REFERENCE, AMOUNT)
+
+        verify(launcher).startPayment(
+            reference = REFERENCE,
+            amount = AMOUNT,
+            isAutoReturnEnabled = false,
+            isRetryEnabled = true,
+            isShareEnabled = false,
             preferences = preferences
         )
     }
@@ -211,12 +231,14 @@ class ClipPaymentTest {
     private fun getPaymentInstance(
         isAutoReturnEnabled: Boolean = false,
         isRetryEnabled: Boolean = true,
+        isShareEnabled: Boolean = true,
         preferences: PaymentPreferences = getPaymentPreferences()
     ) = ClipPayment(
         useCase,
         launcher,
         isAutoReturnEnabled,
         isRetryEnabled,
+        isShareEnabled,
         preferences,
         listener
     )
@@ -255,6 +277,7 @@ class ClipPaymentTest {
 
         private const val AUTO_RETURN = false
         private const val RETRY = true
+        private const val SHARE = true
 
         private const val IS_QPS_ENABLED = false
         private const val IS_MSI_ENABLED = true


### PR DESCRIPTION
# PinPad

# Descripción
Se agrega la opción de deshabilitar las opciones de compartir dentro de la pantalla de éxito con tarjeta en el flujo transaccional. Por default si no es usado se tomara el valor **true**