### PR TITLE
[FIX] Actualizar el workflow de Dependency Review a v4

### DIFF
--- a/.github/workflows/dependecy-review.yml
+++ b/.github/workflows/dependecy-review.yml
@@ -13,17 +13,5 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
-      # TEMP debug (F2F-834): diagnosticar por qué GITHUB_TOKEN no puede leer
-      # dependency-graph/compare — retirar antes del merge
-      - name: 'Debug dependency-graph API access'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          curl -s -o /tmp/resp.json -w "HTTP %{http_code}\n" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/dependency-graph/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
-          cat /tmp/resp.json
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependecy-review.yml
+++ b/.github/workflows/dependecy-review.yml
@@ -1,15 +1,14 @@
 name: 'Dependency Review'
 on: [pull_request]
 
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
-  security-events: write
-
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      security-events: write
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/dependecy-review.yml
+++ b/.github/workflows/dependecy-review.yml
@@ -1,12 +1,17 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  security-events: write
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v1
-
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependecy-review.yml
+++ b/.github/workflows/dependecy-review.yml
@@ -5,10 +5,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
-      pull-requests: write
-      security-events: write
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/dependecy-review.yml
+++ b/.github/workflows/dependecy-review.yml
@@ -13,5 +13,17 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
+      # TEMP debug (F2F-834): diagnosticar por qué GITHUB_TOKEN no puede leer
+      # dependency-graph/compare — retirar antes del merge
+      - name: 'Debug dependency-graph API access'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl -s -o /tmp/resp.json -w "HTTP %{http_code}\n" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/dependency-graph/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+          cat /tmp/resp.json
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza el workflow de Dependency Review, que está fallando en **todas** las corridas recientes (p. ej. en #47 y también en ramas previas como `improve/q3.1-2026/version-bump`) con:

> Dependency review is not supported on this repository. Please ensure that Dependency graph is enabled

El mensaje es engañoso: el dependency graph **sí está habilitado** (el endpoint `dependency-graph/compare` responde 200). El problema es `actions/dependency-review-action@v1`, una versión de 2022 que ya no es compatible con el API actual, más `checkout@v3` (deprecado, avisos de Node 20).

## Cambios

- `actions/checkout@v3` → `@v4`
- `actions/dependency-review-action@v1` → `@v4`
- Bloque `permissions` explícito, como recomienda la v4

Se adopta el mismo patrón ya usado en la org: `android.standalone-readers-custom-launcher`, `nextjs.bill-payments-ui` y `node.mobile-qa-automation`. Quedan 11 repos más en `v1` con el mismo problema latente (los SDKs de Android, `pinpad-payments-api`, `trains-mobile`, entre otros).

## ¿Cómo probar?

El propio check `dependency-review` de este PR corre con el workflow actualizado (los workflows de `pull_request` se toman de la rama del PR): debe pasar en verde. Tras el merge, re-correr el check en #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)